### PR TITLE
Enhance portfolio stats and styling

### DIFF
--- a/_data/experience.yml
+++ b/_data/experience.yml
@@ -1,7 +1,7 @@
 - company: Delta Airlines
   url: 'https://www.delta.com/'
   time: Dec 2022 - Present
-  position: Senior Developer 1
+  position: Senior Developer 2
   description: Working for Delta Sync Exclusive Hub
   
 - company: Publicis Sapient

--- a/_includes/background.html
+++ b/_includes/background.html
@@ -2,7 +2,7 @@
   <div class="section__title">Background</div>
   <div class="section__content">
     <p>
-      I'm currently a Senior Developer 1 at
+      I'm currently a Senior Developer 2 at
       <a class="underline-link" href="https://www.delta.com/" target="_blank">Delta Airlines</a>, building <a class="underline-link" href="https://www.delta.com/" target="_blank">Digital Cabin Experience domain products</a> for a leading US-based airline company with some awesome people. I graduated
       <a class="underline-link" href="#" target="_blank">KNIT</a> in 2018 after completing three awesome internships at
       <a class="underline-link" href="http://syandan.com/" target="_blank">Syandan</a>,

--- a/_includes/leetcode.html
+++ b/_includes/leetcode.html
@@ -1,0 +1,7 @@
+<section class="section leetcode-stats">
+  <div class="section__title">LeetCode Stats</div>
+  <div class="section__content">
+    <p>Problems solved: <span id="leetcode-solved-2">0</span></p>
+    <p>Ranking: <span id="leetcode-rank-2">-</span></p>
+  </div>
+</section>

--- a/_includes/open-source.html
+++ b/_includes/open-source.html
@@ -1,5 +1,5 @@
 <section class="section open-source">
-  <div class="section__title">Open Source</div>
+  <div class="section__title">GitHub Stats</div>
   <div class="section__content">
     <p>GitHub repositories: <span id="repo-count">0</span></p>
     <p>Total contributions (last year): <span id="contrib-count">0</span></p>

--- a/css/scifi.css
+++ b/css/scifi.css
@@ -1,7 +1,15 @@
 body {
-  background: radial-gradient(circle at center, #01010c 0%, #000000 100%);
+  background: linear-gradient(-45deg, #0f0c29, #302b63, #24243e, #0f0c29);
+  background-size: 400% 400%;
+  animation: gradientBG 15s ease infinite;
   font-family: 'Orbitron', 'Apercu', sans-serif;
   color: #0ff;
+}
+
+@keyframes gradientBG {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
 }
 
 .section__title {
@@ -71,4 +79,18 @@ a:hover {
   height: 20px;
   background: url('../img/emojis/rocket.png') no-repeat center/contain;
   filter: drop-shadow(0 0 5px #0ff);
+}
+
+.featured-projects .project,
+.other-projects .project {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(0, 255, 255, 0.2);
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 0 10px rgba(0, 255, 255, 0.2);
+  margin-bottom: 20px;
+}
+
+.featured-projects .project__pic img {
+  border-radius: 5px;
 }

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@ layout: default
   {% include featured-projects.html %}
   {% include open-source.html %}
   {% include competitive-programming.html %}
+  {% include leetcode.html %}
   {% include other-projects.html %}
   {% include footer.html %}
   {% include top-button.html %}

--- a/js/visualizations.js
+++ b/js/visualizations.js
@@ -124,12 +124,17 @@
   }
 
   function fetchLeetCodeStats(user) {
-    if (!document.getElementById('leetcode-solved')) return;
     fetch(`https://leetcode-stats-api.herokuapp.com/${user}`)
       .then(r => r.json())
       .then(d => {
-        document.getElementById('leetcode-solved').textContent = d.totalSolved;
-        document.getElementById('leetcode-rank').textContent = d.ranking;
+        const solved = document.getElementById('leetcode-solved');
+        if (solved) solved.textContent = d.totalSolved;
+        const solved2 = document.getElementById('leetcode-solved-2');
+        if (solved2) solved2.textContent = d.totalSolved;
+        const rank = document.getElementById('leetcode-rank');
+        if (rank) rank.textContent = d.ranking;
+        const rank2 = document.getElementById('leetcode-rank-2');
+        if (rank2) rank2.textContent = d.ranking;
       })
       .catch(() => {});
   }


### PR DESCRIPTION
## Summary
- update Delta role to Senior Developer 2
- rename open source section to GitHub Stats
- add dedicated LeetCode stats section
- style featured projects and other projects as cards
- animate background gradient for sci‑fi look
- adjust JS to fill multiple LeetCode stat blocks

## Testing
- `npm run build` *(fails: gulp not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841593d4eac83308cb55df6d745b117