### PR TITLE
Revamp portfolio visuals and stats

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # Site settings
 name: Adarsh Pandey
 title: Adarsh Pandey | Front End Software Engineer
-description: Design-minded front-end software engineer focused on building scalable products and experiences
+description: Design-minded full stack developer focused on building scalable products and experiences
 url: https://learneradarsh.github.io/
 baseurl: ''
 email: learner.adarsh@gmail.com

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,7 +1,7 @@
 # Site settings
 name: Adarsh Pandey
 title: Adarsh Pandey | Front End Software Engineer
-description: Design-minded front-end software engineer focused on building beautiful interfaces and experiences
+description: Design-minded full stack developer focused on building scalable products and experiences
 url: https://learneradarsh.github.io/
 baseurl: ''
 email: learner.adarsh@gmail.com

--- a/_data/skill_chart.json
+++ b/_data/skill_chart.json
@@ -1,17 +1,17 @@
 [
-  {"item": "JavaScript", "level": 90, "years": 5},
-  {"item": "TypeScript", "level": 80, "years": 4},
+  {"item": "JavaScript", "level": 90, "years": 7},
+  {"item": "TypeScript", "level": 80, "years": 6},
   {"item": "HTML", "level": 95, "years": 6},
   {"item": "CSS/Sass", "level": 90, "years": 6},
-  {"item": "React", "level": 85, "years": 4},
-  {"item": "Node.js", "level": 70, "years": 3},
-  {"item": "Angular", "level": 60, "years": 2},
+  {"item": "React", "level": 85, "years": 7},
+  {"item": "Node.js", "level": 70, "years": 6},
+  {"item": "Angular", "level": 60, "years": 7},
   {"item": "Bootstrap", "level": 75, "years": 4},
   {"item": "Postman", "level": 80, "years": 3},
   {"item": "Docker", "level": 65, "years": 2},
   {"item": "Wordpress", "level": 70, "years": 3},
   {"item": "Joomla", "level": 40, "years": 1},
-  {"item": "jQuery", "level": 70, "years": 4},
+  {"item": "jQuery", "level": 70, "years": 5},
   {"item": "AWS", "level": 50, "years": 2},
   {"item": "Figma", "level": 60, "years": 1}
 ]

--- a/_data/skills.yml
+++ b/_data/skills.yml
@@ -1,10 +1,10 @@
 languages:
   - item: JavaScript
     level: 90
-    years: 5
+    years: 7
   - item: TypeScript
     level: 80
-    years: 4
+    years: 6
   - item: HTML
     level: 95
     years: 6
@@ -15,13 +15,13 @@ languages:
 frameworks:
   - item: React
     level: 85
-    years: 4
+    years: 7
   - item: Node.js
     level: 70
-    years: 3
+    years: 6
   - item: Angular
     level: 60
-    years: 2
+    years: 7
   - item: Bootstrap
     level: 75
     years: 4
@@ -43,7 +43,7 @@ others:
     years: 1
   - item: jQuery
     level: 70
-    years: 4
+    years: 5
   - item: AWS
     level: 50
     years: 2

--- a/_includes/experience.html
+++ b/_includes/experience.html
@@ -1,7 +1,7 @@
 <section class="section experience">
   <div class="section__title">Experience</div>
   <div class="section__content">
-    <div class="experience-summary">More than 5 years of professional web development experience.</div>
+    <div class="experience-summary">More than 7 years of professional web development experience.</div>
     <ul class="timeline">
       {% for job in site.data.experience %}
       <li class="timeline__item">

--- a/_includes/intro.html
+++ b/_includes/intro.html
@@ -4,7 +4,7 @@
   </h1>
 
   <h2 class="intro__tagline">I'm
-    <span class="name">Adarsh Pandey</span>, a design-minded front-end software engineer focused on building scalable products &amp; experiences
+    <span class="name">Adarsh Pandey</span>, a design-minded full stack developer focused on building scalable products &amp; experiences
     <span class="emoji"></span>
   </h2>
 

--- a/_includes/open-source.html
+++ b/_includes/open-source.html
@@ -2,6 +2,13 @@
   <div class="section__title">GitHub Stats</div>
   <div class="section__content">
     <canvas id="github-stats-chart" height="200"></canvas>
+    <ul id="github-kpis" class="github-kpis">
+      <li>Total Commits: <span id="totalCommits">-</span></li>
+      <li>Total PRs: <span id="totalPRs">-</span></li>
+      <li>Total Issues: <span id="totalIssues">-</span></li>
+      <li>Total Contributions: <span id="totalContributions">-</span></li>
+      <li>Longest Streak: <span id="longestStreak">-</span></li>
+    </ul>
     <div id="github-heatmap"></div>
   </div>
 </section>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,6 +7,7 @@ layout: compress
   {% include head.html %}
 </head>
 <body>
+  <canvas id="matrix-canvas"></canvas>
   {{ content }}
   {% include scripts.html %}
 </body>

--- a/_scripts/chatbot.js
+++ b/_scripts/chatbot.js
@@ -1,6 +1,6 @@
 const chatData = [
   { keywords: ['hi', 'hello'], text: 'Hey there!' },
-  { keywords: ['name'], text: "I'm Adarsh Pandey, a front-end software engineer." },
+  { keywords: ['name'], text: "I'm Adarsh Pandey, a full stack developer." },
   { keywords: ['skills'], text: 'I work with JavaScript, TypeScript, React, Angular and more.' },
   { keywords: ['experience', 'work'], text: 'Currently Senior Developer 1 at Delta Airlines. Previously at Publicis Sapient and ThoughtWorks.' },
   { keywords: ['hobbies', 'interests'], text: 'I enjoy traveling and playing squash when not coding.' }

--- a/_scripts/main.js
+++ b/_scripts/main.js
@@ -79,4 +79,32 @@ $(function() {
     if (prevBtn) prevBtn.addEventListener('click', () => showSlide(index - 1));
     if (nextBtn) nextBtn.addEventListener('click', () => showSlide(index + 1));
   }
+
+  const matrixCanvas = document.getElementById('matrix-canvas');
+  if (matrixCanvas) {
+    let width = matrixCanvas.width = window.innerWidth;
+    let height = matrixCanvas.height = window.innerHeight;
+    const columns = Math.floor(width / 20);
+    const drops = Array(columns).fill(0);
+    const ctx = matrixCanvas.getContext('2d');
+
+    const draw = () => {
+      ctx.fillStyle = 'rgba(0,0,0,0.05)';
+      ctx.fillRect(0, 0, width, height);
+      ctx.fillStyle = '#0F0';
+      ctx.font = '15px monospace';
+      drops.forEach((y, i) => {
+        const text = String.fromCharCode(0x30A0 + Math.random() * 96);
+        ctx.fillText(text, i * 20, y);
+        if (y > height && Math.random() > 0.975) drops[i] = 0;
+        else drops[i] = y + 20;
+      });
+    };
+
+    setInterval(draw, 50);
+    window.addEventListener('resize', () => {
+      width = matrixCanvas.width = window.innerWidth;
+      height = matrixCanvas.height = window.innerHeight;
+    });
+  }
 });

--- a/_scss/partials/_base.scss
+++ b/_scss/partials/_base.scss
@@ -238,3 +238,13 @@ strong {
   opacity: 1;
   transform: translateZ(0);
 }
+
+#matrix-canvas {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+  pointer-events: none;
+}

--- a/_scss/partials/_featured-projects.scss
+++ b/_scss/partials/_featured-projects.scss
@@ -105,10 +105,20 @@
   .project-carousel {
     overflow: hidden;
     position: relative;
+    max-width: 100%;
+    height: 350px;
   }
 
   .project-carousel .project {
     display: none;
+    height: 100%;
+  }
+
+  .project-carousel .project img {
+    height: 100%;
+    width: auto;
+    max-height: 100%;
+    object-fit: contain;
   }
 
   .project-carousel .project.active {

--- a/_scss/partials/_open-source.scss
+++ b/_scss/partials/_open-source.scss
@@ -7,4 +7,13 @@
     max-width: 100%;
     margin-bottom: 10px;
   }
+
+  .github-kpis {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 10px 0;
+    li {
+      margin: 3px 0;
+    }
+  }
 }

--- a/css/main.css
+++ b/css/main.css
@@ -4,9 +4,10 @@
 .featured-projects .carousel-prev,.featured-projects .carousel-next{position:absolute;top:50%;transform:translateY(-50%);background:none;border:none;font-size:2rem;color:#333;cursor:pointer;z-index:2}
 .featured-projects .carousel-prev{left:10px}
 .featured-projects .carousel-next{right:10px}
-.featured-projects .project-carousel{overflow:hidden;position:relative}
-.featured-projects .project-carousel .project{display:none}
+.featured-projects .project-carousel{overflow:hidden;position:relative;max-width:100%;height:350px}
+.featured-projects .project-carousel .project{display:none;height:100%};.featured-projects .project-carousel .project img{height:100%;width:auto;max-height:100%;object-fit:contain}
 .featured-projects .project-carousel .project.active{display:block}
 .featured-projects .section__title{text-align:center;margin-bottom:20px}
-.open-source canvas{max-width:100%;margin-bottom:10px}
+.open-source canvas{max-width:100%;margin-bottom:10px}.open-source .github-kpis{list-style:none;padding:0;margin:0 0 10px 0}.open-source .github-kpis li{margin:3px 0}
 .competitive-programming canvas{max-width:100%;margin-bottom:10px}
+#matrix-canvas{position:fixed;top:0;left:0;width:100%;height:100%;z-index:-1;pointer-events:none}

--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@ layout: default
   {% include background.html %}
   {% include skills.html %}
   {% include experience.html %}
-  {% include code-stats.html %}
   {% include featured-projects.html %}
   {% include open-source.html %}
   {% include competitive-programming.html %}

--- a/js/chatbot.js
+++ b/js/chatbot.js
@@ -1,6 +1,6 @@
 const chatData = [
   { keywords: ['hi', 'hello'], text: 'Hey there!' },
-  { keywords: ['name'], text: "I'm Adarsh Pandey, a front-end software engineer." },
+  { keywords: ['name'], text: "I'm Adarsh Pandey, a full stack developer." },
   { keywords: ['skills'], text: 'I work with JavaScript, TypeScript, React, Angular and more.' },
   { keywords: ['experience', 'work'], text: 'Currently Senior Developer 1 at Delta Airlines. Previously at Publicis Sapient and ThoughtWorks.' },
   { keywords: ['hobbies', 'interests'], text: 'I enjoy traveling and playing squash when not coding.' }

--- a/js/main.js
+++ b/js/main.js
@@ -79,4 +79,32 @@ $(function() {
     if (prevBtn) prevBtn.addEventListener('click', () => showSlide(index - 1));
     if (nextBtn) nextBtn.addEventListener('click', () => showSlide(index + 1));
   }
+
+  const matrixCanvas = document.getElementById('matrix-canvas');
+  if (matrixCanvas) {
+    let width = matrixCanvas.width = window.innerWidth;
+    let height = matrixCanvas.height = window.innerHeight;
+    const columns = Math.floor(width / 20);
+    const drops = Array(columns).fill(0);
+    const ctx = matrixCanvas.getContext('2d');
+
+    const draw = () => {
+      ctx.fillStyle = 'rgba(0,0,0,0.05)';
+      ctx.fillRect(0, 0, width, height);
+      ctx.fillStyle = '#0F0';
+      ctx.font = '15px monospace';
+      drops.forEach((y, i) => {
+        const text = String.fromCharCode(0x30A0 + Math.random() * 96);
+        ctx.fillText(text, i * 20, y);
+        if (y > height && Math.random() > 0.975) drops[i] = 0;
+        else drops[i] = y + 20;
+      });
+    };
+
+    setInterval(draw, 50);
+    window.addEventListener('resize', () => {
+      width = matrixCanvas.width = window.innerWidth;
+      height = matrixCanvas.height = window.innerHeight;
+    });
+  }
 });

--- a/js/visualizations.js
+++ b/js/visualizations.js
@@ -110,9 +110,20 @@
     Promise.all([repoReq, contribReq]).then(([u, c]) => {
       const repoCount = u.public_repos || 0;
       let contributions = 0;
+      let commitCount = 0;
+      let prCount = 0;
+      let issueCount = 0;
+      let longestStreak = 0;
+
       if (c.years && c.years.length) {
         const latest = c.years[c.years.length - 1];
-        contributions = latest.total;
+        contributions = latest.total || 0;
+        longestStreak = latest.longestStreak || 0;
+        if (latest.contributions) {
+          commitCount = latest.contributions.commitContributions || 0;
+          prCount = latest.contributions.pullRequestContributions || 0;
+          issueCount = latest.contributions.issueContributions || 0;
+        }
       }
 
       const chartEl = document.getElementById('github-stats-chart');
@@ -129,6 +140,17 @@
           options: { plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true } } }
         });
       }
+
+      const setText = (id, val) => {
+        const el = document.getElementById(id);
+        if (el) el.textContent = val;
+      };
+
+      setText('totalCommits', commitCount);
+      setText('totalPRs', prCount);
+      setText('totalIssues', issueCount);
+      setText('totalContributions', contributions);
+      setText('longestStreak', longestStreak);
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "learneradarsh",
   "version": "0.0.0",
-  "description": "Design-minded front-end software engineer focused on building beautiful interfaces and experiences",
+  "description": "Design-minded full stack developer focused on building scalable products and experiences",
   "repository": {
     "type": "git",
     "url": "https://github.com/learneradarsh/learneradarsh.github.io.git"


### PR DESCRIPTION
## Summary
- modernize tagline and config descriptions
- show 7+ years in experience section
- refresh skills and experience data
- improve featured projects carousel responsiveness
- include GitHub KPIs and matrix-style background animation
- drop code stats section

## Testing
- `npm run build` *(fails: gulp not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841fc14c7b0833085bccc6eeed4db64