### PR TITLE
Fix background canvas placement and remove empty GitHub stats

### DIFF
--- a/_includes/open-source.html
+++ b/_includes/open-source.html
@@ -2,13 +2,6 @@
   <div class="section__title">GitHub Stats</div>
   <div class="section__content">
     <canvas id="github-stats-chart" height="200"></canvas>
-    <ul id="github-kpis" class="github-kpis">
-      <li>Total Commits: <span id="totalCommits">-</span></li>
-      <li>Total PRs: <span id="totalPRs">-</span></li>
-      <li>Total Issues: <span id="totalIssues">-</span></li>
-      <li>Total Contributions: <span id="totalContributions">-</span></li>
-      <li>Longest Streak: <span id="longestStreak">-</span></li>
-    </ul>
     <div id="github-heatmap"></div>
   </div>
 </section>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,8 +7,8 @@ layout: compress
   {% include head.html %}
 </head>
 <body>
-  <canvas id="matrix-canvas"></canvas>
   {{ content }}
+  <canvas id="matrix-canvas"></canvas>
   {% include scripts.html %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- keep matrix background canvas behind the page content
- simplify GitHub stats section by removing zero-value KPIs

## Testing
- `npm run build` *(fails: gulp not found)*

------
https://chatgpt.com/codex/tasks/task_e_68420023ae1483308589d4290bef191f