### PR TITLE
Enhance intro with tech animation and interactive resume download

### DIFF
--- a/_data/experience_chart.json
+++ b/_data/experience_chart.json
@@ -1,0 +1,7 @@
+[
+  {"company": "Delta Airlines", "years": 1.5},
+  {"company": "Publicis Sapient", "years": 1.9},
+  {"company": "ThoughtWorks", "years": 1.0},
+  {"company": "Moonraft", "years": 1.0},
+  {"company": "LearnShiz Techies", "years": 0.7}
+]

--- a/_includes/experience.html
+++ b/_includes/experience.html
@@ -2,6 +2,7 @@
   <div class="section__title">Experience</div>
   <div class="section__content">
     <div class="experience-summary">More than 7 years of professional web development experience.</div>
+    <canvas id="experienceChart" width="600" height="300" data-experience='{{ site.data.experience_chart | jsonify }}'></canvas>
     <ul class="timeline">
       {% for job in site.data.experience %}
       <li class="timeline__item">

--- a/_includes/intro.html
+++ b/_includes/intro.html
@@ -1,19 +1,34 @@
 <header class="intro">
-  <h1 class="intro__hello">Hello!
-    <span class="emoji wave-hand animated"></span>
-  </h1>
+  <div class="intro__left">
+    <h1 class="intro__hello">Hello!
+      <span class="emoji wave-hand animated"></span>
+    </h1>
 
-  <h2 class="intro__tagline">I'm
-    <span class="name">Adarsh Pandey</span>, a design-minded full stack developer focused on building scalable products &amp; experiences
-    <span class="emoji"></span>
-  </h2>
+    <h2 class="intro__tagline">I'm
+      <span class="name">Adarsh Pandey</span>, a design-minded full stack developer focused on building scalable products &amp; experiences
+      <span class="emoji"></span>
+    </h2>
 
-  <h3 class="intro__contact">
-    <span>Hiring&quest;</span>
-    <span class="emoji pointer"></span>
-    
-    <span>
-      <a href="https://drive.google.com/file/d/1AX5VMlGrS8XHuldPwF3mcw_GWYdynL2g/view?usp=sharing" target="_blank" class="highlight-link">Download Resume</a>
-    </span>
-  </h3>
+    <h3 class="intro__contact">
+      <span>Hiring&quest;</span>
+      <span class="emoji pointer"></span>
+
+      <span>
+        <a href="#" id="resume-link" class="highlight-link">Download Resume</a>
+      </span>
+    </h3>
+  </div>
+  <div class="intro__right">
+    <canvas id="techCanvas"></canvas>
+  </div>
+  <div id="resume-modal" class="modal">
+    <div class="modal-content">
+      <span id="modal-close">&times;</span>
+      <p>Enter your email to download the resume:</p>
+      <form id="resume-form">
+        <input type="email" id="resume-email" required placeholder="Your email" />
+        <button type="submit">Download</button>
+      </form>
+    </div>
+  </div>
 </header>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,8 +1,10 @@
 <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.1/jquery.min.js' type="text/javascript" charset="utf-8"></script>
 <script src="https://unpkg.com/scrollreveal/dist/scrollreveal.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://unpkg.com/three@0.152.2/build/three.min.js"></script>
 <link rel="stylesheet" href="https://unpkg.com/github-calendar@latest/dist/github-calendar-responsive.css"/>
 <script src="https://unpkg.com/github-calendar@latest/dist/github-calendar.min.js"></script>
 <script src="js/main.js" type="text/javascript" charset="utf-8"></script>
 <script src="js/chatbot.js" type="text/javascript"></script>
 <script src="js/visualizations.js" type="text/javascript"></script>
+<script src="js/intro-three.js" type="text/javascript"></script>

--- a/_includes/summary.html
+++ b/_includes/summary.html
@@ -3,9 +3,15 @@
   <div class="section__content">
     <p>Passionate full-stack developer who enjoys turning complex problems into elegant solutions.</p>
     <div class="summary-icons" style="margin-top:10px;">
-      <img src="{{site.baseurl}}/img/social/github.svg" alt="GitHub" style="height:30px;width:30px;margin:0 5px;"/>
-      <img src="{{site.baseurl}}/img/social/leetcode.svg" alt="LeetCode" style="height:30px;width:30px;margin:0 5px;"/>
-      <img src="{{site.baseurl}}/img/social/linkedin.svg" alt="LinkedIn" style="height:30px;width:30px;margin:0 5px;"/>
+      <a href="https://github.com/learneradarsh" target="_blank">
+        <img src="{{site.baseurl}}/img/social/github.svg" alt="GitHub" style="height:30px;width:30px;margin:0 5px;"/>
+      </a>
+      <a href="https://leetcode.com/learneradarsh" target="_blank">
+        <img src="{{site.baseurl}}/img/social/leetcode.svg" alt="LeetCode" style="height:30px;width:30px;margin:0 5px;"/>
+      </a>
+      <a href="https://www.linkedin.com/in/learneradarsh" target="_blank">
+        <img src="{{site.baseurl}}/img/social/linkedin.svg" alt="LinkedIn" style="height:30px;width:30px;margin:0 5px;"/>
+      </a>
     </div>
   </div>
 </section>

--- a/_scripts/visualizations.js
+++ b/_scripts/visualizations.js
@@ -1,6 +1,7 @@
 (function() {
   const radarEl = document.getElementById('skillRadar');
   const barEl = document.getElementById('experienceBar');
+  const expChartEl = document.getElementById('experienceChart');
 
   function buildRadar() {
     if (!radarEl) return;
@@ -63,6 +64,25 @@
     });
   }
 
+  function buildExperienceChart() {
+    if (!expChartEl) return;
+    const data = JSON.parse(expChartEl.dataset.experience);
+    const labels = data.map(d => d.company);
+    const values = data.map(d => d.years);
+    new Chart(expChartEl, {
+      type: 'bar',
+      data: {
+        labels: labels,
+        datasets: [{
+          label: 'Years',
+          data: values,
+          backgroundColor: 'rgba(153, 102, 255, 0.6)'
+        }]
+      },
+      options: { plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true } } }
+    });
+  }
+
   function onVisible(el, callback) {
     if (!el) return;
     const observer = new IntersectionObserver(entries => {
@@ -78,6 +98,7 @@
 
   onVisible(radarEl, buildRadar);
   onVisible(barEl, buildBar);
+  onVisible(expChartEl, buildExperienceChart);
 
   function fetchGitHubStats() {
     const contributions = 120;

--- a/_scss/partials/_experience.scss
+++ b/_scss/partials/_experience.scss
@@ -3,6 +3,10 @@
     font-weight: 600;
     margin-bottom: 20px;
   }
+  #experienceChart {
+    margin: 20px 0;
+    max-width: 100%;
+  }
   .timeline {
     position: relative;
     padding-left: 30px;

--- a/_scss/partials/_intro.scss
+++ b/_scss/partials/_intro.scss
@@ -2,8 +2,9 @@
   padding: 120px 100px;
   height: 100vh;
   display: flex;
-  flex-direction: column;
-  justify-content: space-around;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
   max-width: 1440px;
   margin: 0 auto;
   @include weird-medium {
@@ -14,6 +15,7 @@
   }
   @include mobile {
     padding: 70px 50px;
+    flex-direction: column;
   }
 
   &__hello, &__tagline {
@@ -130,6 +132,54 @@
       &:hover {
         box-shadow: inset 0 -33px 0 0 $blue;
         color: $white;
+      }
+    }
+  }
+
+  &__left {
+    flex: 1 1 50%;
+  }
+
+  &__right {
+    flex: 1 1 40%;
+    height: 300px;
+    canvas {
+      width: 100%;
+      height: 100%;
+      display: block;
+    }
+  }
+
+  #resume-modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+    &.show {
+      display: flex;
+    }
+    .modal-content {
+      background: $white;
+      padding: 20px;
+      border-radius: 4px;
+      color: $black;
+      form {
+        display: flex;
+        margin-top: 10px;
+        input[type='email'] {
+          flex: 1;
+          padding: 5px;
+          margin-right: 5px;
+        }
+        button {
+          padding: 5px 10px;
+        }
       }
     }
   }

--- a/js/intro-three.js
+++ b/js/intro-three.js
@@ -1,0 +1,25 @@
+(function() {
+  const canvas = document.getElementById('techCanvas');
+  if (!canvas || typeof THREE === 'undefined') return;
+  const renderer = new THREE.WebGLRenderer({ canvas, alpha: true });
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(75, canvas.clientWidth / canvas.clientHeight, 0.1, 1000);
+  renderer.setSize(canvas.clientWidth, canvas.clientHeight);
+  const geometry = new THREE.BoxGeometry();
+  const material = new THREE.MeshNormalMaterial();
+  const cube = new THREE.Mesh(geometry, material);
+  scene.add(cube);
+  camera.position.z = 2;
+  function animate() {
+    requestAnimationFrame(animate);
+    cube.rotation.x += 0.01;
+    cube.rotation.y += 0.01;
+    renderer.render(scene, camera);
+  }
+  animate();
+  window.addEventListener('resize', () => {
+    camera.aspect = canvas.clientWidth / canvas.clientHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(canvas.clientWidth, canvas.clientHeight);
+  });
+})();

--- a/js/main.js
+++ b/js/main.js
@@ -109,4 +109,24 @@ $(function() {
       drawStars();
     });
   }
+
+  const resumeLink = document.getElementById('resume-link');
+  const resumeModal = document.getElementById('resume-modal');
+  const modalClose = document.getElementById('modal-close');
+  const resumeForm = document.getElementById('resume-form');
+
+  if (resumeLink && resumeModal && modalClose && resumeForm) {
+    resumeLink.addEventListener('click', e => {
+      e.preventDefault();
+      resumeModal.classList.add('show');
+    });
+    modalClose.addEventListener('click', () => {
+      resumeModal.classList.remove('show');
+    });
+    resumeForm.addEventListener('submit', e => {
+      e.preventDefault();
+      resumeModal.classList.remove('show');
+      window.open('https://drive.google.com/file/d/1AX5VMlGrS8XHuldPwF3mcw_GWYdynL2g/view?usp=sharing', '_blank');
+    });
+  }
 });

--- a/js/visualizations.js
+++ b/js/visualizations.js
@@ -2,6 +2,7 @@
   const radarEl = document.getElementById('skillRadar');
   const barEl = document.getElementById('experienceBar');
   const codeRatioEl = document.getElementById('codeRatioChart');
+  const expChartEl = document.getElementById('experienceChart');
 
   function buildRadar() {
     if (!radarEl) return;
@@ -61,6 +62,25 @@
           }
         }
       }
+    });
+  }
+
+  function buildExperienceChart() {
+    if (!expChartEl) return;
+    const data = JSON.parse(expChartEl.dataset.experience);
+    const labels = data.map(d => d.company);
+    const values = data.map(d => d.years);
+    new Chart(expChartEl, {
+      type: 'bar',
+      data: {
+        labels: labels,
+        datasets: [{
+          label: 'Years',
+          data: values,
+          backgroundColor: 'rgba(153, 102, 255, 0.6)'
+        }]
+      },
+      options: { plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true } } }
     });
   }
 
@@ -161,6 +181,7 @@
   onVisible(radarEl, buildRadar);
   onVisible(barEl, buildBar);
   onVisible(codeRatioEl, buildCodeRatio);
+  onVisible(expChartEl, buildExperienceChart);
 
   fetchGitHubStats();
   fetchLeetCodeStats('learneradarsh');


### PR DESCRIPTION
## Summary
- animate the intro with a Three.js canvas and hook up resume email popup
- add bar chart for work experience
- link summary icons to external profiles
- include Three.js script

## Testing
- `npm run build` *(fails: `gulp` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684285e07734833097a348b9d5151863